### PR TITLE
chore: revert version back, was bumped by mistake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
           name: Link the module being tested to the samples.
           command: |
             cd samples/
-            npm link @google-cloud/monitoring
+            npm link ../
             npm install
             cd ..
       - run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/monitoring",
-  "version": "0.5.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -81,9 +81,9 @@
       }
     },
     "@google-cloud/nodejs-repo-tools": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@google-cloud/nodejs-repo-tools/-/nodejs-repo-tools-2.2.4.tgz",
-      "integrity": "sha512-yHxW7JvhnqgoIftv6dAn1r/9AEcPuumD0xXggdYHmDeyf38OMYyjTk92gP9vflTOee1JhM0vOarwGrlKYUbmnQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/nodejs-repo-tools/-/nodejs-repo-tools-2.2.6.tgz",
+      "integrity": "sha512-bDEgNBAJ8kfYWrpifg+D7rXs8NUBUUeu2I6NWkcL9IOXg86rblu7xnhFHRxBMcvytJ+7WY4pvkCLxO1v3QBsXg==",
       "dev": true,
       "requires": {
         "ava": "0.25.0",
@@ -1900,9 +1900,9 @@
       "integrity": "sha512-ZXyOOm83p7X8p3s0IYM3VeueNmHpkk/yMlP8CLeOnEcu6hIwPH7YjZBvhQkR0ZFS2DqZAxKtJ/M5fcuv3OU5BA=="
     },
     "@types/node": {
-      "version": "8.9.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
-      "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ=="
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.1.tgz",
+      "integrity": "sha512-X/pIUOcgpX7xxKsmdPCMKeDBefsGH/4D/IuJ1gIHbqgWI0qEy/yMKeqaN/sT+rzV9UpAXAfd0kLOVExRmZrXIg=="
     },
     "acorn": {
       "version": "4.0.13",
@@ -2019,9 +2019,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
     "ansi-regex": {
@@ -2265,9 +2265,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw=="
     },
     "auto-bind": {
       "version": "1.2.0",
@@ -2286,7 +2286,7 @@
         "@ava/write-file-atomic": "2.2.0",
         "@concordance/react": "1.0.0",
         "@ladjs/time-require": "0.1.4",
-        "ansi-escapes": "3.0.0",
+        "ansi-escapes": "3.1.0",
         "ansi-styles": "3.2.1",
         "arr-flatten": "1.1.0",
         "array-union": "1.0.2",
@@ -2363,7 +2363,7 @@
         "supports-color": "5.3.0",
         "trim-off-newlines": "1.0.1",
         "unique-temp-dir": "1.0.0",
-        "update-notifier": "2.3.0"
+        "update-notifier": "2.4.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2675,7 +2675,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "espower-location-detector": "1.0.0",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -2822,7 +2822,7 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
@@ -2846,7 +2846,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -3078,6 +3078,12 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "dev": true
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -3128,6 +3134,14 @@
         "lowercase-keys": "1.0.0",
         "normalize-url": "2.0.1",
         "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+          "dev": true
+        }
       }
     },
     "caching-transform": {
@@ -3169,7 +3183,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "deep-equal": "1.0.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -3751,11 +3765,12 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
+        "buffer-from": "1.0.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.5",
         "typedarray": "0.0.6"
@@ -3792,9 +3807,9 @@
       }
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
         "dot-prop": "4.2.0",
@@ -3839,9 +3854,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+      "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3907,7 +3922,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "dashdash": {
@@ -3995,7 +4010,7 @@
       "requires": {
         "globby": "5.0.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
@@ -4179,7 +4194,7 @@
       "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
       "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "empower-core": "0.6.2"
       }
     },
@@ -4198,7 +4213,7 @@
       "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.3"
+        "core-js": "2.5.4"
       }
     },
     "end-of-stream": {
@@ -4231,9 +4246,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.41",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
-      "integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
+      "version": "0.10.42",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -4254,7 +4269,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-symbol": "3.1.1"
       }
     },
@@ -4265,7 +4280,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -4279,7 +4294,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -4292,7 +4307,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "es6-weak-map": {
@@ -4302,7 +4317,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -4372,15 +4387,15 @@
       }
     },
     "eslint": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.0.tgz",
-      "integrity": "sha512-r83L5CuqaocDvfwdojbz68b6tCUk8KJkqfppO+gmSAQqYCzTr0bCSMu6A6yFCLKG65j5eKcKUw4Cw4Yl4gfWkg==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.3.2",
-        "concat-stream": "1.6.1",
+        "concat-stream": "1.6.2",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
         "doctrine": "2.1.0",
@@ -4392,7 +4407,7 @@
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "11.3.0",
+        "globals": "11.4.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
@@ -4408,7 +4423,7 @@
         "path-is-inside": "1.0.2",
         "pluralize": "7.0.0",
         "progress": "2.0.0",
-        "regexpp": "1.0.1",
+        "regexpp": "1.1.0",
         "require-uncached": "1.0.3",
         "semver": "5.5.0",
         "strip-ansi": "4.0.0",
@@ -4433,9 +4448,9 @@
           }
         },
         "globals": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
           "dev": true
         },
         "strip-ansi": {
@@ -4563,7 +4578,7 @@
       "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
       "dev": true,
       "requires": {
-        "is-url": "1.2.3",
+        "is-url": "1.2.4",
         "path-is-absolute": "1.0.1",
         "source-map": "0.5.7",
         "xtend": "4.0.1"
@@ -4625,7 +4640,7 @@
       "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "requires": {
-        "core-js": "2.5.3"
+        "core-js": "2.5.4"
       }
     },
     "esquery": {
@@ -4664,7 +4679,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "execa": {
@@ -4909,7 +4924,7 @@
         "glob-parent": "3.1.0",
         "is-glob": "4.0.0",
         "merge2": "1.2.1",
-        "micromatch": "3.1.9"
+        "micromatch": "3.1.10"
       }
     },
     "fast-json-stable-stringify": {
@@ -6231,7 +6246,7 @@
       "integrity": "sha512-ebtmWgi/ooR5Nl63qRVZZ6VLM6JOb5zTNxTT/ZAU8yfMOdcauoOZNNMOVg0pCmTjqWXeuuVbgPP0CwO5UHHzBQ==",
       "requires": {
         "globby": "7.1.1",
-        "power-assert": "1.4.4",
+        "power-assert": "1.5.0",
         "protobufjs": "6.8.6"
       },
       "dependencies": {
@@ -6264,7 +6279,7 @@
         "into-stream": "3.1.0",
         "is-retry-allowed": "1.1.0",
         "isurl": "1.0.0",
-        "lowercase-keys": "1.0.0",
+        "lowercase-keys": "1.0.1",
         "mimic-response": "1.0.0",
         "p-cancelable": "0.3.0",
         "p-timeout": "2.0.1",
@@ -7042,7 +7057,7 @@
         "axios": "0.18.0",
         "google-p12-pem": "1.0.2",
         "jws": "3.1.4",
-        "mime": "2.2.0",
+        "mime": "2.2.1",
         "pify": "3.0.0"
       }
     },
@@ -7336,7 +7351,7 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.0.0",
+        "ansi-escapes": "3.1.0",
         "chalk": "2.3.2",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
@@ -7627,9 +7642,9 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
@@ -7711,9 +7726,9 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-url": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.3.tgz",
-      "integrity": "sha512-vmOHLvzbcnsdFz8wQPXj1lgI5SE8AUlUGMenzuZzRFjoReb1WB+pLt9GrIo7BTker+aTcwrjTDle7odioWeqyw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
     },
     "is-utf8": {
@@ -7813,7 +7828,7 @@
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "marked": "0.3.17",
+        "marked": "0.3.19",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -7842,9 +7857,9 @@
       "dev": true
     },
     "json-parse-better-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
     "json-schema": {
@@ -8155,9 +8170,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
     "lru-cache": {
@@ -8198,9 +8213,9 @@
       }
     },
     "marked": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz",
-      "integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
     "matcher": {
@@ -8383,9 +8398,9 @@
       "dev": true
     },
     "micromatch": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
-      "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
@@ -8403,9 +8418,9 @@
       }
     },
     "mime": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.2.0.tgz",
-      "integrity": "sha512-0Qz9uF1ATtl8RKJG4VRfOymh7PyEor6NbrI/61lRfuRe4vx9SNATrvAeTj2EWVRKjEQGskrzWkJBBY5NbaVHIA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.2.1.tgz",
+      "integrity": "sha512-8QKdX8CfqnkIn19mnv3Zq78RugzDXZNrcewbZrjf8h0R6aN5Daizum/OoXxqVVhkFW3Ow4LFSn5iOi7qJJOMoA=="
     },
     "mime-db": {
       "version": "1.33.0",
@@ -8475,9 +8490,9 @@
       }
     },
     "mocha": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.4.tgz",
-      "integrity": "sha512-nMOpAPFosU1B4Ix1jdhx5e3q7XO55ic5a8cgYvW27CequcEY+BabS0kUVL1Cw1V5PuVHZWeNRWFLmEPexo79VA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
+      "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.1",
@@ -11745,7 +11760,7 @@
             "is-redirect": "1.0.0",
             "is-retry-allowed": "1.1.0",
             "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
+            "lowercase-keys": "1.0.1",
             "safe-buffer": "5.1.1",
             "timed-out": "4.0.1",
             "unzip-response": "2.0.1",
@@ -11916,7 +11931,7 @@
           "dev": true,
           "requires": {
             "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "json-parse-better-errors": "1.0.2"
           }
         }
       }
@@ -11951,9 +11966,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "6.0.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
-      "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
+      "version": "6.0.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+      "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
@@ -11970,9 +11985,9 @@
       }
     },
     "power-assert": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.4.4.tgz",
-      "integrity": "sha1-kpXqdDcZb1pgH95CDwQmMRhtdRc=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.5.0.tgz",
+      "integrity": "sha512-WaWSw+Ts283o6dzxW1BxIxoaHok7aSSGx4SaR6dW62Pk31ynv9DERDieuZpPYv5XaJ+H+zdcOaJQ+PvlasAOVw==",
       "requires": {
         "define-properties": "1.1.2",
         "empower": "1.2.3",
@@ -11986,7 +12001,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "power-assert-context-traversal": "1.1.1"
       }
     },
@@ -11997,7 +12012,7 @@
       "requires": {
         "acorn": "4.0.13",
         "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
       }
@@ -12007,7 +12022,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "estraverse": "4.2.0"
       }
     },
@@ -12016,7 +12031,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "power-assert-context-formatter": "1.1.1",
         "power-assert-context-reducer-ast": "1.1.2",
         "power-assert-renderer-assertion": "1.1.1",
@@ -12044,7 +12059,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "diff-match-patch": "1.0.0",
         "power-assert-renderer-base": "1.1.1",
         "stringifier": "1.3.0",
@@ -12056,7 +12071,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "power-assert-renderer-base": "1.1.1",
         "power-assert-util-string-width": "1.1.1",
         "stringifier": "1.3.0"
@@ -12153,7 +12168,7 @@
         "@protobufjs/pool": "1.1.0",
         "@protobufjs/utf8": "1.1.0",
         "@types/long": "3.0.32",
-        "@types/node": "8.9.5",
+        "@types/node": "8.10.1",
         "long": "4.0.0"
       }
     },
@@ -12351,9 +12366,9 @@
       }
     },
     "regexpp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.0.1.tgz",
-      "integrity": "sha512-8Ph721maXiOYSLtaDGKVmDn5wdsNaF6Px85qFNeMPQq0r8K5Y10tgP6YuR65Ws35n4DvzFcCxEnRNBIXQunzLw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
     },
     "regexpu-core": {
@@ -12549,7 +12564,7 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "1.0.0"
+        "lowercase-keys": "1.0.1"
       }
     },
     "restore-cursor": {
@@ -12647,7 +12662,7 @@
         "lodash.isplainobject": "4.0.6",
         "lodash.isstring": "4.0.1",
         "lodash.mergewith": "4.6.1",
-        "postcss": "6.0.20",
+        "postcss": "6.0.21",
         "srcset": "1.0.0",
         "xtend": "4.0.1"
       }
@@ -12919,7 +12934,7 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "requires": {
-        "atob": "2.0.3",
+        "atob": "2.1.0",
         "decode-uri-component": "0.2.0",
         "resolve-url": "0.2.1",
         "source-map-url": "0.4.0",
@@ -13135,7 +13150,7 @@
       "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
@@ -13719,15 +13734,16 @@
       "dev": true
     },
     "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
+      "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
       "dev": true,
       "requires": {
         "boxen": "1.3.0",
         "chalk": "2.3.2",
-        "configstore": "3.1.1",
+        "configstore": "3.1.2",
         "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
         "is-installed-globally": "0.1.0",
         "is-npm": "1.0.0",
         "latest-version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/monitoring",
   "description": "Stackdriver Monitoring API client for Node.js",
-  "version": "0.5.0",
+  "version": "0.4.1",
   "license": "Apache-2.0",
   "author": "Google Inc",
   "engines": {

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -81,7 +81,7 @@
       }
     },
     "@google-cloud/monitoring": {
-      "version": "0.5.0",
+      "version": "0.4.1",
       "requires": {
         "extend": "3.0.1",
         "google-gax": "0.16.0",
@@ -152,7 +152,7 @@
           }
         },
         "@google-cloud/nodejs-repo-tools": {
-          "version": "2.2.4",
+          "version": "2.2.6",
           "bundled": true,
           "requires": {
             "ava": "0.25.0",
@@ -1720,7 +1720,7 @@
           "bundled": true
         },
         "@types/node": {
-          "version": "8.9.5",
+          "version": "8.10.1",
           "bundled": true
         },
         "acorn": {
@@ -1813,7 +1813,7 @@
           }
         },
         "ansi-escapes": {
-          "version": "3.0.0",
+          "version": "3.1.0",
           "bundled": true
         },
         "ansi-regex": {
@@ -2006,7 +2006,7 @@
           "bundled": true
         },
         "atob": {
-          "version": "2.0.3",
+          "version": "2.1.0",
           "bundled": true
         },
         "auto-bind": {
@@ -2022,7 +2022,7 @@
             "@ava/write-file-atomic": "2.2.0",
             "@concordance/react": "1.0.0",
             "@ladjs/time-require": "0.1.4",
-            "ansi-escapes": "3.0.0",
+            "ansi-escapes": "3.1.0",
             "ansi-styles": "3.2.1",
             "arr-flatten": "1.1.0",
             "array-union": "1.0.2",
@@ -2099,7 +2099,7 @@
             "supports-color": "5.3.0",
             "trim-off-newlines": "1.0.1",
             "unique-temp-dir": "1.0.0",
-            "update-notifier": "2.3.0"
+            "update-notifier": "2.4.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -2354,7 +2354,7 @@
             "babel-generator": "6.26.1",
             "babylon": "6.18.0",
             "call-matcher": "1.0.1",
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "espower-location-detector": "1.0.0",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
@@ -2471,7 +2471,7 @@
           "requires": {
             "babel-core": "6.26.0",
             "babel-runtime": "6.26.0",
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "home-or-tmp": "2.0.0",
             "lodash": "4.17.5",
             "mkdirp": "0.5.1",
@@ -2491,7 +2491,7 @@
           "version": "6.26.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -2684,6 +2684,10 @@
           "version": "1.0.1",
           "bundled": true
         },
+        "buffer-from": {
+          "version": "1.0.0",
+          "bundled": true
+        },
         "builtin-modules": {
           "version": "1.1.1",
           "bundled": true
@@ -2727,6 +2731,12 @@
             "lowercase-keys": "1.0.0",
             "normalize-url": "2.0.1",
             "responselike": "1.0.2"
+          },
+          "dependencies": {
+            "lowercase-keys": {
+              "version": "1.0.0",
+              "bundled": true
+            }
           }
         },
         "caching-transform": {
@@ -2760,7 +2770,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "deep-equal": "1.0.1",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
@@ -3222,9 +3232,10 @@
           "bundled": true
         },
         "concat-stream": {
-          "version": "1.6.1",
+          "version": "1.6.2",
           "bundled": true,
           "requires": {
+            "buffer-from": "1.0.0",
             "inherits": "2.0.3",
             "readable-stream": "2.3.5",
             "typedarray": "0.0.6"
@@ -3257,7 +3268,7 @@
           }
         },
         "configstore": {
-          "version": "3.1.1",
+          "version": "3.1.2",
           "bundled": true,
           "requires": {
             "dot-prop": "4.2.0",
@@ -3293,7 +3304,7 @@
           }
         },
         "core-js": {
-          "version": "2.5.3",
+          "version": "2.5.4",
           "bundled": true
         },
         "core-util-is": {
@@ -3347,7 +3358,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "es5-ext": "0.10.41"
+            "es5-ext": "0.10.42"
           }
         },
         "dashdash": {
@@ -3417,7 +3428,7 @@
           "requires": {
             "globby": "5.0.0",
             "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
             "object-assign": "4.1.1",
             "pify": "2.3.0",
             "pinkie-promise": "2.0.1",
@@ -3565,7 +3576,7 @@
           "version": "1.2.3",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "empower-core": "0.6.2"
           }
         },
@@ -3581,7 +3592,7 @@
           "bundled": true,
           "requires": {
             "call-signature": "0.0.2",
-            "core-js": "2.5.3"
+            "core-js": "2.5.4"
           }
         },
         "end-of-stream": {
@@ -3607,7 +3618,7 @@
           }
         },
         "es5-ext": {
-          "version": "0.10.41",
+          "version": "0.10.42",
           "bundled": true,
           "requires": {
             "es6-iterator": "2.0.3",
@@ -3624,7 +3635,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41",
+            "es5-ext": "0.10.42",
             "es6-symbol": "3.1.1"
           }
         },
@@ -3633,7 +3644,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41",
+            "es5-ext": "0.10.42",
             "es6-iterator": "2.0.3",
             "es6-set": "0.1.5",
             "es6-symbol": "3.1.1",
@@ -3645,7 +3656,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41",
+            "es5-ext": "0.10.42",
             "es6-iterator": "2.0.3",
             "es6-symbol": "3.1.1",
             "event-emitter": "0.3.5"
@@ -3656,7 +3667,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41"
+            "es5-ext": "0.10.42"
           }
         },
         "es6-weak-map": {
@@ -3664,7 +3675,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41",
+            "es5-ext": "0.10.42",
             "es6-iterator": "2.0.3",
             "es6-symbol": "3.1.1"
           }
@@ -3720,13 +3731,13 @@
           }
         },
         "eslint": {
-          "version": "4.19.0",
+          "version": "4.19.1",
           "bundled": true,
           "requires": {
             "ajv": "5.5.2",
             "babel-code-frame": "6.26.0",
             "chalk": "2.3.2",
-            "concat-stream": "1.6.1",
+            "concat-stream": "1.6.2",
             "cross-spawn": "5.1.0",
             "debug": "3.1.0",
             "doctrine": "2.1.0",
@@ -3738,7 +3749,7 @@
             "file-entry-cache": "2.0.0",
             "functional-red-black-tree": "1.0.1",
             "glob": "7.1.2",
-            "globals": "11.3.0",
+            "globals": "11.4.0",
             "ignore": "3.3.7",
             "imurmurhash": "0.1.4",
             "inquirer": "3.3.0",
@@ -3754,7 +3765,7 @@
             "path-is-inside": "1.0.2",
             "pluralize": "7.0.0",
             "progress": "2.0.0",
-            "regexpp": "1.0.1",
+            "regexpp": "1.1.0",
             "require-uncached": "1.0.3",
             "semver": "5.5.0",
             "strip-ansi": "4.0.0",
@@ -3775,7 +3786,7 @@
               }
             },
             "globals": {
-              "version": "11.3.0",
+              "version": "11.4.0",
               "bundled": true
             },
             "strip-ansi": {
@@ -3879,7 +3890,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "is-url": "1.2.3",
+            "is-url": "1.2.4",
             "path-is-absolute": "1.0.1",
             "source-map": "0.5.7",
             "xtend": "4.0.1"
@@ -3930,7 +3941,7 @@
           "version": "1.7.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3"
+            "core-js": "2.5.4"
           }
         },
         "esquery": {
@@ -3960,7 +3971,7 @@
           "bundled": true,
           "requires": {
             "d": "1.0.0",
-            "es5-ext": "0.10.41"
+            "es5-ext": "0.10.42"
           }
         },
         "execa": {
@@ -4171,7 +4182,7 @@
             "glob-parent": "3.1.0",
             "is-glob": "4.0.0",
             "merge2": "1.2.1",
-            "micromatch": "3.1.9"
+            "micromatch": "3.1.10"
           }
         },
         "fast-json-stable-stringify": {
@@ -4515,7 +4526,7 @@
           "bundled": true,
           "requires": {
             "globby": "7.1.1",
-            "power-assert": "1.4.4",
+            "power-assert": "1.5.0",
             "protobufjs": "6.8.6"
           },
           "dependencies": {
@@ -4545,7 +4556,7 @@
             "into-stream": "3.1.0",
             "is-retry-allowed": "1.1.0",
             "isurl": "1.0.0",
-            "lowercase-keys": "1.0.0",
+            "lowercase-keys": "1.0.1",
             "mimic-response": "1.0.0",
             "p-cancelable": "0.3.0",
             "p-timeout": "2.0.1",
@@ -5312,7 +5323,7 @@
             "axios": "0.18.0",
             "google-p12-pem": "1.0.2",
             "jws": "3.1.4",
-            "mime": "2.2.0",
+            "mime": "2.2.1",
             "pify": "3.0.0"
           }
         },
@@ -5546,7 +5557,7 @@
           "version": "3.3.0",
           "bundled": true,
           "requires": {
-            "ansi-escapes": "3.0.0",
+            "ansi-escapes": "3.1.0",
             "chalk": "2.3.2",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",
@@ -5778,7 +5789,7 @@
           "bundled": true
         },
         "is-path-in-cwd": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true,
           "requires": {
             "is-path-inside": "1.0.1"
@@ -5839,7 +5850,7 @@
           "bundled": true
         },
         "is-url": {
-          "version": "1.2.3",
+          "version": "1.2.4",
           "bundled": true
         },
         "is-utf8": {
@@ -5916,7 +5927,7 @@
             "escape-string-regexp": "1.0.5",
             "js2xmlparser": "3.0.0",
             "klaw": "2.0.0",
-            "marked": "0.3.17",
+            "marked": "0.3.19",
             "mkdirp": "0.5.1",
             "requizzle": "0.2.1",
             "strip-json-comments": "2.0.1",
@@ -5939,7 +5950,7 @@
           "bundled": true
         },
         "json-parse-better-errors": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "bundled": true
         },
         "json-schema": {
@@ -6177,7 +6188,7 @@
           }
         },
         "lowercase-keys": {
-          "version": "1.0.0",
+          "version": "1.0.1",
           "bundled": true
         },
         "lru-cache": {
@@ -6211,7 +6222,7 @@
           }
         },
         "marked": {
-          "version": "0.3.17",
+          "version": "0.3.19",
           "bundled": true
         },
         "matcher": {
@@ -6355,7 +6366,7 @@
           "bundled": true
         },
         "micromatch": {
-          "version": "3.1.9",
+          "version": "3.1.10",
           "bundled": true,
           "requires": {
             "arr-diff": "4.0.0",
@@ -6374,7 +6385,7 @@
           }
         },
         "mime": {
-          "version": "2.2.0",
+          "version": "2.2.1",
           "bundled": true
         },
         "mime-db": {
@@ -6432,7 +6443,7 @@
           }
         },
         "mocha": {
-          "version": "5.0.4",
+          "version": "5.0.5",
           "bundled": true,
           "requires": {
             "browser-stdout": "1.3.1",
@@ -9257,7 +9268,7 @@
                 "is-redirect": "1.0.0",
                 "is-retry-allowed": "1.1.0",
                 "is-stream": "1.1.0",
-                "lowercase-keys": "1.0.0",
+                "lowercase-keys": "1.0.1",
                 "safe-buffer": "5.1.1",
                 "timed-out": "4.0.1",
                 "unzip-response": "2.0.1",
@@ -9390,7 +9401,7 @@
               "bundled": true,
               "requires": {
                 "error-ex": "1.3.1",
-                "json-parse-better-errors": "1.0.1"
+                "json-parse-better-errors": "1.0.2"
               }
             }
           }
@@ -9418,7 +9429,7 @@
           "bundled": true
         },
         "postcss": {
-          "version": "6.0.20",
+          "version": "6.0.21",
           "bundled": true,
           "requires": {
             "chalk": "2.3.2",
@@ -9433,7 +9444,7 @@
           }
         },
         "power-assert": {
-          "version": "1.4.4",
+          "version": "1.5.0",
           "bundled": true,
           "requires": {
             "define-properties": "1.1.2",
@@ -9447,7 +9458,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "power-assert-context-traversal": "1.1.1"
           }
         },
@@ -9457,7 +9468,7 @@
           "requires": {
             "acorn": "4.0.13",
             "acorn-es7-plugin": "1.1.7",
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "espurify": "1.7.0",
             "estraverse": "4.2.0"
           }
@@ -9466,7 +9477,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "estraverse": "4.2.0"
           }
         },
@@ -9474,7 +9485,7 @@
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "power-assert-context-formatter": "1.1.1",
             "power-assert-context-reducer-ast": "1.1.2",
             "power-assert-renderer-assertion": "1.1.1",
@@ -9499,7 +9510,7 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "diff-match-patch": "1.0.0",
             "power-assert-renderer-base": "1.1.1",
             "stringifier": "1.3.0",
@@ -9510,7 +9521,7 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "power-assert-renderer-base": "1.1.1",
             "power-assert-util-string-width": "1.1.1",
             "stringifier": "1.3.0"
@@ -9587,7 +9598,7 @@
             "@protobufjs/pool": "1.1.0",
             "@protobufjs/utf8": "1.1.0",
             "@types/long": "3.0.32",
-            "@types/node": "8.9.5",
+            "@types/node": "8.10.1",
             "long": "4.0.0"
           }
         },
@@ -9748,7 +9759,7 @@
           }
         },
         "regexpp": {
-          "version": "1.0.1",
+          "version": "1.1.0",
           "bundled": true
         },
         "regexpu-core": {
@@ -9902,7 +9913,7 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "lowercase-keys": "1.0.0"
+            "lowercase-keys": "1.0.1"
           }
         },
         "restore-cursor": {
@@ -9980,7 +9991,7 @@
             "lodash.isplainobject": "4.0.6",
             "lodash.isstring": "4.0.1",
             "lodash.mergewith": "4.6.1",
-            "postcss": "6.0.20",
+            "postcss": "6.0.21",
             "srcset": "1.0.0",
             "xtend": "4.0.1"
           }
@@ -10207,7 +10218,7 @@
           "version": "0.5.1",
           "bundled": true,
           "requires": {
-            "atob": "2.0.3",
+            "atob": "2.1.0",
             "decode-uri-component": "0.2.0",
             "resolve-url": "0.2.1",
             "source-map-url": "0.4.0",
@@ -10386,7 +10397,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.4",
             "traverse": "0.6.6",
             "type-name": "2.0.2"
           }
@@ -10850,13 +10861,14 @@
           "bundled": true
         },
         "update-notifier": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "requires": {
             "boxen": "1.3.0",
             "chalk": "2.3.2",
-            "configstore": "3.1.1",
+            "configstore": "3.1.2",
             "import-lazy": "2.1.0",
+            "is-ci": "1.1.0",
             "is-installed-globally": "0.1.0",
             "is-npm": "1.0.0",
             "latest-version": "3.1.0",
@@ -11110,7 +11122,7 @@
             "@ava/write-file-atomic": "2.2.0",
             "@concordance/react": "1.0.0",
             "@ladjs/time-require": "0.1.4",
-            "ansi-escapes": "3.0.0",
+            "ansi-escapes": "3.1.0",
             "ansi-styles": "3.2.1",
             "arr-flatten": "1.1.0",
             "array-union": "1.0.2",
@@ -11187,7 +11199,7 @@
             "supports-color": "5.3.0",
             "trim-off-newlines": "1.0.1",
             "unique-temp-dir": "1.0.0",
-            "update-notifier": "2.3.0"
+            "update-notifier": "2.4.0"
           }
         },
         "cliui": {
@@ -11344,9 +11356,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
     "ansi-regex": {
@@ -11551,7 +11563,7 @@
         "time-require": "0.1.2",
         "trim-off-newlines": "1.0.1",
         "unique-temp-dir": "1.0.0",
-        "update-notifier": "2.3.0"
+        "update-notifier": "2.4.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -11857,7 +11869,7 @@
         "babel-generator": "6.26.1",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "espower-location-detector": "1.0.0",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -12004,7 +12016,7 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
@@ -12028,7 +12040,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -12176,6 +12188,14 @@
         "lowercase-keys": "1.0.0",
         "normalize-url": "2.0.1",
         "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+          "dev": true
+        }
       }
     },
     "caching-transform": {
@@ -12217,7 +12237,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "deep-equal": "1.0.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -12485,9 +12505,9 @@
       }
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
         "dot-prop": "4.2.0",
@@ -12527,9 +12547,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+      "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
       "dev": true
     },
     "core-util-is": {
@@ -12670,7 +12690,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.3"
+        "core-js": "2.5.4"
       }
     },
     "equal-length": {
@@ -12706,7 +12726,7 @@
       "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
       "dev": true,
       "requires": {
-        "is-url": "1.2.3",
+        "is-url": "1.2.4",
         "path-is-absolute": "1.0.1",
         "source-map": "0.5.7",
         "xtend": "4.0.1"
@@ -12724,7 +12744,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3"
+        "core-js": "2.5.4"
       }
     },
     "estraverse": {
@@ -13832,7 +13852,7 @@
         "into-stream": "3.1.0",
         "is-retry-allowed": "1.1.0",
         "isurl": "1.0.0",
-        "lowercase-keys": "1.0.0",
+        "lowercase-keys": "1.0.1",
         "mimic-response": "1.0.0",
         "p-cancelable": "0.3.0",
         "p-timeout": "2.0.1",
@@ -14268,9 +14288,9 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-url": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.3.tgz",
-      "integrity": "sha512-vmOHLvzbcnsdFz8wQPXj1lgI5SE8AUlUGMenzuZzRFjoReb1WB+pLt9GrIo7BTker+aTcwrjTDle7odioWeqyw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true
     },
     "is-utf8": {
@@ -14344,9 +14364,9 @@
       "dev": true
     },
     "json-parse-better-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
     "json5": {
@@ -14534,9 +14554,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
     "lru-cache": {
@@ -16680,7 +16700,7 @@
             "is-redirect": "1.0.0",
             "is-retry-allowed": "1.1.0",
             "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
+            "lowercase-keys": "1.0.1",
             "safe-buffer": "5.1.1",
             "timed-out": "4.0.1",
             "unzip-response": "2.0.1",
@@ -16814,7 +16834,7 @@
           "dev": true,
           "requires": {
             "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.1"
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "pify": {
@@ -17193,7 +17213,7 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "1.0.0"
+        "lowercase-keys": "1.0.1"
       }
     },
     "restore-cursor": {
@@ -17801,15 +17821,16 @@
       "dev": true
     },
     "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
+      "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
       "dev": true,
       "requires": {
         "boxen": "1.3.0",
         "chalk": "2.3.2",
-        "configstore": "3.1.1",
+        "configstore": "3.1.2",
         "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
         "is-installed-globally": "0.1.0",
         "is-npm": "1.0.0",
         "latest-version": "3.1.0",

--- a/samples/package.json
+++ b/samples/package.json
@@ -12,7 +12,7 @@
     "test": "repo-tools test run --cmd ava -- -T 3m --verbose system-test/*.test.js"
   },
   "dependencies": {
-    "@google-cloud/monitoring": "0.5.0",
+    "@google-cloud/monitoring": "0.4.1",
     "yargs": "10.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #31 - for some reason the version was set to 0.5.0 and never released (the latest on NPM is 0.4.1). Let's put the version back, and when I release 0.5.0 (soon), I'll make a separate PR bumping the version.

Also, making sure `lint` tasks links samples to the main package correctly.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
