### PR TITLE
chore: make environment variable naming consistent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
           command: npm run system-test
           environment:
             GOOGLE_APPLICATION_CREDENTIALS: .circleci/key.json
-            SMOKE_TEST_PROJECT: long-door-651
+            GCLOUD_PROJECT: long-door-651
       - run:
           name: Remove unencrypted key.
           command: rm .circleci/key.json


### PR DESCRIPTION
I changed the environment variable name in system tests to `GCLOUD_PROJECT` but forgot to fix CircleCI configuration. Here is the fix.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
