### PR TITLE
add resource type filter to alerts test

### DIFF
--- a/samples/system-test/alerts.test.js
+++ b/samples/system-test/alerts.test.js
@@ -44,7 +44,7 @@ test.before(async () => {
         {
           displayName: 'Condition 1',
           conditionAbsent: {
-            filter: `metric.type = "cloudfunctions.googleapis.com/function/execution_count"`,
+            filter: `resource.type = "cloud_function" AND metric.type = "cloudfunctions.googleapis.com/function/execution_count"`,
             aggregations: [
               {
                 alignmentPeriod: {
@@ -75,7 +75,7 @@ test.before(async () => {
         {
           displayName: 'Condition 2',
           conditionAbsent: {
-            filter: `metric.type = "cloudfunctions.googleapis.com/function/execution_count"`,
+            filter: `resource.type = "cloud_function" AND metric.type = "cloudfunctions.googleapis.com/function/execution_count"`,
             aggregations: [
               {
                 alignmentPeriod: {


### PR DESCRIPTION
Fixes #43 by providing `resource.type` in the filter expression as requested by server:

details: 'Field alert_policy.conditions[0].condition_absent.filter had an invalid value of "metric.type = "cloudfunctions.googleapis.com/function/execution_count"": **must specify a restriction on "resource.type" in the filter;** see "https://cloud.google.com/monitoring/api/resources" for a list of available resource types.'

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
