### PR TITLE
test: fix failing tests due to leaks

### DIFF
--- a/samples/alerts.js
+++ b/samples/alerts.js
@@ -41,7 +41,12 @@ async function backupPolicies(projectId) {
     name: client.projectPath(projectId),
   };
 
-  const [policies] = await client.listAlertPolicies(listAlertPoliciesRequest);
+  let [policies] = await client.listAlertPolicies(listAlertPoliciesRequest);
+
+  // filter out any policies created by tests for this sample
+  policies = policies.filter(policy => {
+    return !policy.displayName.startsWith('gcloud-tests-');
+  });
 
   fs.writeFileSync(
     './policies_backup.json',

--- a/samples/package.json
+++ b/samples/package.json
@@ -5,7 +5,9 @@
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "repository": "googleapis/nodejs-monitoring",
-  "files": [ "*.js" ],
+  "files": [
+    "*.js"
+  ],
   "engines": {
     "node": ">=8"
   },
@@ -20,6 +22,7 @@
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
     "mocha": "^5.0.0",
     "proxyquire": "^2.0.1",
-    "sinon": "^7.0.0"
+    "sinon": "^7.0.0",
+    "uuid": "^3.3.2"
   }
 }

--- a/samples/system-test/.eslintrc.yml
+++ b/samples/system-test/.eslintrc.yml
@@ -3,5 +3,3 @@ env:
   mocha: true
 rules:
   node/no-unpublished-require: off
-  node/no-unsupported-features: off
-  no-empty: off

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -18,13 +18,9 @@
 const proxyquire = require(`proxyquire`).noPreserveCache();
 const sinon = require(`sinon`);
 const assert = require('assert');
-const tools = require(`@google-cloud/nodejs-repo-tools`);
 
 const monitoring = proxyquire(`@google-cloud/monitoring`, {});
 const client = new monitoring.MetricServiceClient();
-
-beforeEach(tools.stubConsole);
-afterEach(tools.restoreConsole);
 
 it(`should list time series`, async () => {
   const clientMock = {
@@ -42,7 +38,9 @@ it(`should list time series`, async () => {
             `Done writing time series data.`,
             {},
           ]);
-        } catch (err) {}
+        } catch (err) {
+          // ignore error
+        }
       }, 200);
 
       return result;

--- a/smoke-test/.eslintrc.yml
+++ b/smoke-test/.eslintrc.yml
@@ -1,5 +1,5 @@
 ---
-rules:
-  no-console: off
 env:
   mocha: true
+rules:
+  no-console: off

--- a/system-test/.eslintrc.yml
+++ b/system-test/.eslintrc.yml
@@ -2,5 +2,4 @@
 env:
   mocha: true
 rules:
-  node/no-unpublished-require: off
   no-console: off

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,5 +1,3 @@
 ---
 env:
   mocha: true
-rules:
-  node/no-unpublished-require: off


### PR DESCRIPTION
I don't feel entirely great about the way I had to pollute the sample to make this actually work.  Here's a TL;DR of what was happening:
- The same samples a local file with a list of alert policies
- The the tests add a bunch of things
- The sample restores the list of previous policies

This works great until you run the test twice at the same time :) We start creating a bunch of policies that leak from session to session, and eventually fill up.