### PR TITLE
refactor: modernize and fix the sample tests

### DIFF
--- a/samples/metrics.js
+++ b/samples/metrics.js
@@ -68,7 +68,6 @@ async function createMetricDescriptor(projectId) {
   descriptor.labels.forEach(label => {
     console.log(`  ${label.key} (${label.valueType}) - ${label.description}`);
   });
-
   // [END monitoring_create_metric]
 }
 

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,6 +1,5 @@
 {
   "name": "nodejs-docs-samples-monitoring",
-  "version": "0.0.1",
   "private": true,
   "license": "Apache-2.0",
   "author": "Google Inc.",
@@ -12,17 +11,17 @@
     "node": ">=8"
   },
   "scripts": {
-    "test": "mocha system-test/*.js --timeout 600000"
+    "test": "mocha system-test --timeout 600000"
   },
   "dependencies": {
     "@google-cloud/monitoring": "^0.6.0",
     "yargs": "^12.0.0"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "^3.0.0",
+    "chai": "^4.2.0",
+    "execa": "^1.0.0",
     "mocha": "^5.0.0",
-    "proxyquire": "^2.0.1",
-    "sinon": "^7.0.0",
+    "p-retry": "^3.0.0",
     "uuid": "^3.3.2"
   }
 }

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -18,9 +18,10 @@
 // [START monitoring_quickstart]
 // Imports the Google Cloud client library
 const monitoring = require('@google-cloud/monitoring');
-async function quickStart() {
+
+async function quickstart() {
   // Your Google Cloud Platform project ID
-  const projectId = 'YOUR_PROJECT_ID';
+  const projectId = process.env.GCLOUD_PROJECT || 'YOUR_PROJECT_ID';
 
   // Creates a client
   const client = new monitoring.MetricServiceClient();
@@ -65,6 +66,6 @@ async function quickStart() {
   const [result] = await client.createTimeSeries(request);
   console.log(`Done writing time series data.`, result);
 }
-
-quickStart().catch(console.error);
 // [END monitoring_quickstart]
+
+quickstart().catch(console.error);

--- a/samples/system-test/.eslintrc.yml
+++ b/samples/system-test/.eslintrc.yml
@@ -1,5 +1,3 @@
 ---
 env:
   mocha: true
-rules:
-  node/no-unpublished-require: off

--- a/samples/system-test/uptime.test.js
+++ b/samples/system-test/uptime.test.js
@@ -15,14 +15,13 @@
 
 'use strict';
 
-const path = require(`path`);
-const assert = require('assert');
-const tools = require(`@google-cloud/nodejs-repo-tools`);
+const {assert} = require('chai');
+const execa = require('execa');
 
-const cmd = `node uptime.js`;
-const cwd = path.join(__dirname, `..`);
+const cmd = 'node uptime.js';
 const projectId = process.env.GCLOUD_PROJECT;
 const hostname = 'mydomain.com';
+const exec = async cmd => (await execa.shell(cmd)).stdout;
 
 function getResourceObjects(output) {
   const regex = new RegExp(/^\s*Resource: (.*)$/gm);
@@ -34,98 +33,79 @@ function getResourceObjects(output) {
   return result;
 }
 
-before(tools.checkCredentials);
+describe('uptime', () => {
+  it('should list uptime-check ips', async () => {
+    const output = await exec(`${cmd} list-ips`);
+    assert.match(output, /USA/);
+  });
 
-it(`should list uptime-check ips`, async () => {
-  assert.strictEqual(
-    (await tools.runAsync(`${cmd} list-ips`, cwd)).includes('USA'),
-    true
-  );
-});
+  let id;
 
-let id;
+  it('should create an uptime check', async () => {
+    const output = await exec(`${cmd} create ${hostname}`);
+    const matches = output.match(
+      new RegExp(`ID: projects/${projectId}/uptimeCheckConfigs/(.+)`)
+    );
+    id = matches[1];
+    assert.match(output, /Uptime check created:/);
+    const resources = getResourceObjects(output);
+    assert.strictEqual(resources[0]['type'], 'uptime_url');
+    assert.strictEqual(resources[0]['labels']['host'], hostname);
+    assert.match(output, /Display Name: My Uptime Check/);
+  });
 
-it(`should create an uptime check`, async () => {
-  const results = await tools.runAsyncWithIO(`${cmd} create ${hostname}`, cwd);
-  const output = results.stdout + results.stderr;
-  const matches = output.match(
-    new RegExp(`ID: projects/${projectId}/uptimeCheckConfigs/(.+)`)
-  );
-  id = matches[1];
-  assert.strictEqual(output.includes('Uptime check created:'), true);
-  const resources = getResourceObjects(output);
-  assert.strictEqual(resources[0]['type'], 'uptime_url');
-  assert.strictEqual(resources[0]['labels']['host'], hostname);
-  assert.strictEqual(output.includes('Display Name: My Uptime Check'), true);
-});
+  it('should get an uptime check', async () => {
+    const output = await exec(`${cmd} get ${id}`);
+    assert.match(
+      output,
+      new RegExp(`Retrieving projects/${projectId}/uptimeCheckConfigs/${id}`)
+    );
+    const resources = getResourceObjects(output);
+    assert.strictEqual(resources[0]['type'], 'uptime_url');
+    assert.strictEqual(resources[0]['labels']['host'], hostname);
+  });
 
-it(`should get an uptime check`, async () => {
-  const results = await tools.runAsyncWithIO(`${cmd} get ${id}`, cwd);
-  const output = results.stdout + results.stderr;
-  assert.strictEqual(
-    new RegExp(
-      `Retrieving projects/${projectId}/uptimeCheckConfigs/${id}`
-    ).test(output),
-    true
-  );
-  const resources = getResourceObjects(output);
-  assert.strictEqual(resources[0]['type'], 'uptime_url');
-  assert.strictEqual(resources[0]['labels']['host'], hostname);
-});
+  it('should list uptime checks', async () => {
+    const output = await exec(`${cmd} list`);
+    const resources = getResourceObjects(output);
+    const resourceCount = resources.filter(
+      resource =>
+        resource['type'] === 'uptime_url' &&
+        resource['labels']['host'] === hostname
+    ).length;
+    assert.isAbove(resourceCount, 0);
+    assert.match(output, /Display Name: My Uptime Check/);
+  });
 
-it(`should list uptime checks`, async () => {
-  await tools
-    .tryTest(async assert => {
-      const results = await tools.runAsyncWithIO(`${cmd} list`, cwd);
-      const output = results.stdout + results.stderr;
-      const resources = getResourceObjects(output);
-      assert(
-        resources.filter(
-          resource =>
-            resource['type'] === 'uptime_url' &&
-            resource['labels']['host'] === hostname
-        ).length > 0
-      );
-      assert(/Display Name: My Uptime Check/.test(output));
-    })
-    .start();
-});
+  it('should update an uptime check', async () => {
+    const newDisplayName = 'My New Display';
+    const path = '/';
+    const output = await exec(
+      `${cmd} update ${id} "${newDisplayName}" ${path}`
+    );
+    assert.match(
+      output,
+      new RegExp(
+        `Updating projects/${projectId}/uptimeCheckConfigs/${id} to ${newDisplayName}`
+      )
+    );
+    assert.match(
+      output,
+      new RegExp(
+        `projects/${projectId}/uptimeCheckConfigs/${id} config updated.`
+      )
+    );
+  });
 
-it(`should update an uptime check`, async () => {
-  const newDisplayName = 'My New Display';
-  const path = '/';
-  const results = await tools.runAsyncWithIO(
-    `${cmd} update ${id} "${newDisplayName}" ${path}`,
-    cwd
-  );
-  const output = results.stdout + results.stderr;
-  assert.strictEqual(
-    new RegExp(
-      `Updating projects/${projectId}/uptimeCheckConfigs/${id} to ${newDisplayName}`
-    ).test(output),
-    true
-  );
-  assert.strictEqual(
-    new RegExp(
-      `projects/${projectId}/uptimeCheckConfigs/${id} config updated.`
-    ).test(output),
-    true
-  );
-});
-
-it(`should delete an uptime check`, async () => {
-  const results = await tools.runAsyncWithIO(`${cmd} delete ${id}`, cwd);
-  const output = results.stdout + results.stderr;
-  assert.strictEqual(
-    new RegExp(`Deleting projects/${projectId}/uptimeCheckConfigs/${id}`).test(
-      output
-    ),
-    true
-  );
-  assert.strictEqual(
-    new RegExp(`projects/${projectId}/uptimeCheckConfigs/${id} deleted.`).test(
-      output
-    ),
-    true
-  );
+  it('should delete an uptime check', async () => {
+    const output = await exec(`${cmd} delete ${id}`);
+    assert.match(
+      output,
+      new RegExp(`Deleting projects/${projectId}/uptimeCheckConfigs/${id}`)
+    );
+    assert.match(
+      output,
+      new RegExp(`projects/${projectId}/uptimeCheckConfigs/${id} deleted.`)
+    );
+  });
 });


### PR DESCRIPTION
So the monitoring sample tests have been flaky for as long as I can remember.  In the process of upgrading to mocha/chai/execa, I added retries in a few places, and moved a few things to serial execution to discover what looks to be a few underlying issues with the API.  The result of the investigation was these bugs:
- #190 
- #191 
- #192 

I suspect all of these are related to the underlying API, but it's worth ruling out the client library as well.  Adding @alexander-fenster since he helped with some of the investigation here too :) 

@theacodes - these are bad enough that I think someone needs to take point on reaching out to the monitoring team, and figuring out what's going on.  Since I'm "out of office", do you mind reaching out?