### PR TITLE
test: add log to debug tests

### DIFF
--- a/samples/metrics.js
+++ b/samples/metrics.js
@@ -323,6 +323,7 @@ async function readTimeSeriesAggregate(projectId) {
   const [timeSeries] = await client.listTimeSeries(request);
   console.log('CPU utilization:');
   timeSeries.forEach(data => {
+    console.log(data);
     console.log(data.metric.labels.instance_name);
     console.log(`  Now: ${data.points[0].value.doubleValue}`);
     console.log(`  10 min ago: ${data.points[1].value.doubleValue}`);


### PR DESCRIPTION
This is a wild bug.  Trying to track down #382, and started looking at fusion boards.  
- [presubmit](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod%3Acloud-devrel%2Fclient-libraries%2Fnodejs%2Fpresubmit%2Fgoogleapis%2Fnodejs-monitoring%2Fnode10%2Fsamples-test): ~40% failures
- [continuous](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod%3Acloud-devrel%2Fclient-libraries%2Fnodejs%2Fcontinuous%2Fgoogleapis%2Fnodejs-monitoring%2Fnode10%2Fsamples-test): ~25% failures
- [nightly](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod%3Acloud-devrel%2Fclient-libraries%2Fnodejs%2Fnightly%2Fgoogleapis%2Fnodejs-monitoring%2Fnode10%2Fsamples-test?search_pattern=nodejs-monitoring&include_inactive_projects=false):  100% failures


When the failure happens, it's with this call stack:

```
1) metrics
       should read time series data aggregated:
     Command failed: node metrics.js read-aggregate
metrics.js read-aggregate [projectId]

Aggregates time series data that matches 'compute.googleapis.com/instance/cpu/utilization'.

Options:
  --version        Show version number                                                                         [boolean]
  --projectId, -p                                                                    [string] [default: "long-door-651"]
  --help           Show help                                                                                   [boolean]

TypeError: Cannot read property 'value' of undefined
    at timeSeries.forEach.data (/tmpfs/src/github/nodejs-monitoring/samples/metrics.js:328:49)
    at Array.forEach (<anonymous>)
    at readTimeSeriesAggregate (/tmpfs/src/github/nodejs-monitoring/samples/metrics.js:325:14)
    at process._tickCallback (internal/process/next_tick.js:68:7)

  Error: Command failed: node metrics.js read-aggregate
  metrics.js read-aggregate [projectId]

  Aggregates time series data that matches 'compute.googleapis.com/instance/cpu/utilization'.

  Options:
    --version        Show version number                                                                         [boolean]
    --projectId, -p                                                                    [string] [default: "long-door-651"]
    --help           Show help                                                                                   [boolean]

  TypeError: Cannot read property 'value' of undefined
      at timeSeries.forEach.data (metrics.js:328:49)
      at Array.forEach (<anonymous>)
      at readTimeSeriesAggregate (metrics.js:325:14)
      at process._tickCallback (internal/process/next_tick.js:68:7)

      at checkExecSyncError (child_process.js:629:11)
      at Object.execSync (child_process.js:666:13)
      at execSync (test/metrics.test.js:23:28)
      at Context.it (test/metrics.test.js:154:20)
      at process._tickCallback (internal/process/next_tick.js:68:7)
```

The offending code is here:
```js
// Writes time series data
const [timeSeries] = await client.listTimeSeries(request);
console.log('CPU utilization:');
timeSeries.forEach(data => {
  console.log(data.metric.labels.instance_name);
  console.log(`  Now: ${data.points[0].value.doubleValue}`);
  console.log(`  10 min ago: ${data.points[1].value.doubleValue}`);
});
```

In some cases, who knows which ones, `data.points[1].value` is `undefined`.  This addition adds a little logging so we have a fighting chance of figuring out why.  

