### PR TITLE
refactor(test): use exponential backoff and retry some integration tests

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^7.0.0",
-    "p-retry": "^4.0.0",
     "uuid": "^7.0.0"
   }
 }

--- a/samples/test/metrics.test.js
+++ b/samples/test/metrics.test.js
@@ -18,7 +18,6 @@ const monitoring = require('@google-cloud/monitoring');
 const {assert} = require('chai');
 const {describe, it} = require('mocha');
 const cp = require('child_process');
-const retry = require('p-retry');
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
@@ -30,28 +29,30 @@ const filter = `metric.type="${computeMetricId}"`;
 const projectId = process.env.GCLOUD_PROJECT;
 const resourceId = 'cloudsql_database';
 
-describe('metrics', () => {
+// A helper for delaying integration tests with an exponential backoff.
+// See examples like: https://github.com/googleapis/nodejs-monitoring/issues/190
+const delay = async test => {
+  const retries = test.currentRetry();
+  if (retries === 0) return Promise.resolve(); // no retry on the first failure.
+  const ms = Math.pow(2, retries) * 250;
+  return new Promise(done => {
+    console.info(`retrying "${test.title}" in ${ms}ms`);
+    setTimeout(done, ms);
+  });
+};
+describe('metrics', async () => {
   it('should create a metric descriptors', () => {
     const output = execSync(`${cmd} create`);
     assert.include(output, 'Created custom Metric');
     assert.include(output, `Type: ${customMetricId}`);
   });
 
-  it('should list metric descriptors, including the new custom one', async () => {
-    // The write above appears to be eventually consistent. This retry should
-    // not be needed.  The tracking bug is here:
-    // https://github.com/googleapis/nodejs-monitoring/issues/190
-    await retry(
-      async () => {
-        const output = execSync(`${cmd} list`);
-        assert.include(output, customMetricId);
-        assert.include(output, computeMetricId);
-      },
-      {
-        retries: 10,
-        onFailedAttempt: () => console.warn('Read failed, retrying...'),
-      }
-    );
+  it('should list metric descriptors, including the new custom one', async function() {
+    this.retries(4);
+    await delay(this.test); // delay the start of the test, if this is a retry.
+    const output = execSync(`${cmd} list`);
+    assert.include(output, customMetricId);
+    assert.include(output, computeMetricId);
   });
 
   it('should get a metric descriptor', () => {
@@ -130,7 +131,9 @@ describe('metrics', () => {
     });
   });
 
-  it('should read time series data aggregated', async () => {
+  it('should read time series data aggregated', async function() {
+    this.retries(4);
+    await delay(this.test); // delay the start of the test, if this is a retry.
     const [timeSeries] = await client.listTimeSeries({
       name: client.projectPath(projectId),
       filter: filter,

--- a/samples/test/metrics.test.js
+++ b/samples/test/metrics.test.js
@@ -35,7 +35,8 @@ const resourceId = 'cloudsql_database';
 const delay = async test => {
   const retries = test.currentRetry();
   if (retries === 0) return; // no retry on the first failure.
-  const ms = Math.pow(2, retries) * 250;
+  // see: https://cloud.google.com/storage/docs/exponential-backoff:
+  const ms = Math.pow(2, retries) * 250 + Math.random() * 1000;
   return new Promise(done => {
     console.info(`retrying "${test.title}" in ${ms}ms`);
     setTimeout(done, ms);
@@ -49,7 +50,7 @@ describe('metrics', async () => {
   });
 
   it('should list metric descriptors, including the new custom one', async function() {
-    this.retries(5);
+    this.retries(8);
     await delay(this.test); // delay the start of the test, if this is a retry.
     const output = execSync(`${cmd} list`);
     assert.include(output, customMetricId);

--- a/samples/test/metrics.test.js
+++ b/samples/test/metrics.test.js
@@ -30,7 +30,8 @@ const projectId = process.env.GCLOUD_PROJECT;
 const resourceId = 'cloudsql_database';
 
 // A helper for delaying integration tests with an exponential backoff.
-// See examples like: https://github.com/googleapis/nodejs-monitoring/issues/190
+// See examples like: https://github.com/googleapis/nodejs-monitoring/issues/190,
+// https://github.com/googleapis/nodejs-monitoring/issues/191.
 const delay = async test => {
   const retries = test.currentRetry();
   if (retries === 0) return Promise.resolve(); // no retry on the first failure.

--- a/samples/test/metrics.test.js
+++ b/samples/test/metrics.test.js
@@ -34,7 +34,7 @@ const resourceId = 'cloudsql_database';
 // https://github.com/googleapis/nodejs-monitoring/issues/191.
 const delay = async test => {
   const retries = test.currentRetry();
-  if (retries === 0) return Promise.resolve(); // no retry on the first failure.
+  if (retries === 0) return; // no retry on the first failure.
   const ms = Math.pow(2, retries) * 250;
   return new Promise(done => {
     console.info(`retrying "${test.title}" in ${ms}ms`);
@@ -49,7 +49,7 @@ describe('metrics', async () => {
   });
 
   it('should list metric descriptors, including the new custom one', async function() {
-    this.retries(4);
+    this.retries(5);
     await delay(this.test); // delay the start of the test, if this is a retry.
     const output = execSync(`${cmd} list`);
     assert.include(output, customMetricId);
@@ -133,7 +133,7 @@ describe('metrics', async () => {
   });
 
   it('should read time series data aggregated', async function() {
-    this.retries(4);
+    this.retries(5);
     await delay(this.test); // delay the start of the test, if this is a retry.
     const [timeSeries] = await client.listTimeSeries({
       name: client.projectPath(projectId),

--- a/samples/test/quickstart.test.js
+++ b/samples/test/quickstart.test.js
@@ -25,7 +25,8 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const delay = async test => {
   const retries = test.currentRetry();
   if (retries === 0) return; // no retry on the first failure.
-  const ms = Math.pow(2, retries) * 250;
+  // see: https://cloud.google.com/storage/docs/exponential-backoff:
+  const ms = Math.pow(2, retries) * 250 + Math.random() * 1000;
   return new Promise(done => {
     console.info(`retrying "${test.title}" in ${ms}ms`);
     setTimeout(done, ms);
@@ -33,7 +34,7 @@ const delay = async test => {
 };
 describe('quickstart', () => {
   it('should run the quickstart', async function() {
-    this.retries(5);
+    this.retries(8);
     await delay(this.test); // delay the start of the test, if this is a retry.
     const result = execSync('node quickstart');
     assert.match(result, /Done writing time series data/);

--- a/samples/test/quickstart.test.js
+++ b/samples/test/quickstart.test.js
@@ -17,24 +17,25 @@
 const {assert} = require('chai');
 const {describe, it} = require('mocha');
 const cp = require('child_process');
-const retry = require('p-retry');
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
-
+// A helper for delaying integration tests with an exponential backoff.
+// See examples like: https://github.com/googleapis/nodejs-monitoring/issues/190,
+// https://github.com/googleapis/nodejs-monitoring/issues/191.
+const delay = async test => {
+  const retries = test.currentRetry();
+  if (retries === 0) return Promise.resolve(); // no retry on the first failure.
+  const ms = Math.pow(2, retries) * 250;
+  return new Promise(done => {
+    console.info(`retrying "${test.title}" in ${ms}ms`);
+    setTimeout(done, ms);
+  });
+};
 describe('quickstart', () => {
-  it('should run the quickstart', async () => {
-    // The write in the quickstart appears to be very, very flaky.
-    // This should not be needed.  The tracking bug is here:
-    // https://github.com/googleapis/nodejs-monitoring/issues/191
-    await retry(
-      async () => {
-        const result = execSync('node quickstart');
-        assert.match(result, /Done writing time series data/);
-      },
-      {
-        retries: 10,
-        onFailedAttempt: () => console.warn('Write failed, retrying...'),
-      }
-    );
+  it('should run the quickstart', async function() {
+    this.retries(4);
+    await delay(this.test); // delay the start of the test, if this is a retry.
+    const result = execSync('node quickstart');
+    assert.match(result, /Done writing time series data/);
   });
 });

--- a/samples/test/quickstart.test.js
+++ b/samples/test/quickstart.test.js
@@ -24,7 +24,7 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 // https://github.com/googleapis/nodejs-monitoring/issues/191.
 const delay = async test => {
   const retries = test.currentRetry();
-  if (retries === 0) return Promise.resolve(); // no retry on the first failure.
+  if (retries === 0) return; // no retry on the first failure.
   const ms = Math.pow(2, retries) * 250;
   return new Promise(done => {
     console.info(`retrying "${test.title}" in ${ms}ms`);
@@ -33,7 +33,7 @@ const delay = async test => {
 };
 describe('quickstart', () => {
   it('should run the quickstart', async function() {
-    this.retries(4);
+    this.retries(5);
     await delay(this.test); // delay the start of the test, if this is a retry.
     const result = execSync('node quickstart');
     assert.match(result, /Done writing time series data/);


### PR DESCRIPTION
Talking with the stackdriver folks, in relation to #190 and #191, it was indicated that it's known that operations are eventually consistent. I believe that there's a good chance that #382 is related to this same behavior.

This PR starts pulling in an approach I'd like to start using for flaky integration tests, mainly using [mocha's built in retry support](https://mochajs.org/#retry-tests) and an exponential backoff ([as recommended by GCP](https://cloud.google.com/storage/docs/exponential-backoff)).

I think on a case by case basis, when we're fairly confident it's an upstream service that occasionally causes our samples issues, I think think this is a reasonable approach.

----

As an example of why I think this approach is reasonable for some of these stackdriver errors, here's the error that was forcing retries in the `quickstart.js`:

```bash
rror: 3 INVALID_ARGUMENT: One or more TimeSeries could not be written: One or more points were written more frequently than the maximum sampling period configured for the metric. {Metric: custom.googleapis.com/stores/daily_sales, Timestamps: {Youngest Existing: '2020/04/02-23:12:47.000', New: '2020/04/02-23:12:51.000'}}: timeSeries[0]
    at Object.callErrorFromStatus (/Users/bencoe/google/nodejs-monitoring/node_modules/@grpc/grpc-js/build/src/call.js:30:26)
    at Object.onReceiveStatus (/Users/bencoe/google/nodejs-monitoring/node_modules/@grpc/grpc-js/build/src/client.js:174:52)
```

☝️ our test easily steps on this if, as an example, two suites are running in parallel, and an exponential backoff is a great way to deal with it.

fixes: #382 