### PR TITLE
samples: use modern samples layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,11 @@ npm install @google-cloud/monitoring
 const monitoring = require('@google-cloud/monitoring');
 
 async function quickstart() {
-  // Your Google Cloud Platform project ID
-  const projectId =
-    process.env.GCLOUD_PROJECT ||
-    process.env.GOOGLE_CLOUD_PROJECT ||
-    'YOUR_PROJECT_ID';
-
   // Creates a client
   const client = new monitoring.MetricServiceClient();
+
+  // TODO(developer): Uncomment and set the following variables
+  // const projectId = "PROJECT_ID"
 
   // Prepares an individual data point
   const dataPoint = {
@@ -113,6 +110,7 @@ async function quickstart() {
   const [result] = await client.createTimeSeries(request);
   console.log('Done writing time series data.', result);
 }
+quickstart();
 
 ```
 
@@ -124,7 +122,13 @@ Samples are in the [`samples/`](https://github.com/googleapis/nodejs-monitoring/
 
 | Sample                      | Source Code                       | Try it |
 | --------------------------- | --------------------------------- | ------ |
+| Alerts.backup Policies | [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.backupPolicies.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.backupPolicies.js,samples/README.md) |
+| Alerts.delete Channels | [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.deleteChannels.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.deleteChannels.js,samples/README.md) |
+| Alerts.enable Policies | [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.enablePolicies.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.enablePolicies.js,samples/README.md) |
 | Alerts | [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.js,samples/README.md) |
+| Alerts.list Policies | [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.listPolicies.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.listPolicies.js,samples/README.md) |
+| Alerts.replace Channels | [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.replaceChannels.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.replaceChannels.js,samples/README.md) |
+| Alerts.restore Policies | [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.restorePolicies.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.restorePolicies.js,samples/README.md) |
 | Metrics | [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/metrics.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/metrics.js,samples/README.md) |
 | Quickstart | [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/quickstart.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/quickstart.js,samples/README.md) |
 | Uptime | [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/uptime.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/uptime.js,samples/README.md) |

--- a/samples/README.md
+++ b/samples/README.md
@@ -14,7 +14,13 @@ and a variety of common application components including Cassandra, Nginx, Apach
 
 * [Before you begin](#before-you-begin)
 * [Samples](#samples)
+  * [Alerts.backup Policies](#alerts.backup-policies)
+  * [Alerts.delete Channels](#alerts.delete-channels)
+  * [Alerts.enable Policies](#alerts.enable-policies)
   * [Alerts](#alerts)
+  * [Alerts.list Policies](#alerts.list-policies)
+  * [Alerts.replace Channels](#alerts.replace-channels)
+  * [Alerts.restore Policies](#alerts.restore-policies)
   * [Metrics](#metrics)
   * [Quickstart](#quickstart)
   * [Uptime](#uptime)
@@ -34,6 +40,57 @@ Before running the samples, make sure you've followed the steps outlined in
 
 
 
+### Alerts.backup Policies
+
+View the [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.backupPolicies.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.backupPolicies.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/alerts.backupPolicies.js`
+
+
+-----
+
+
+
+
+### Alerts.delete Channels
+
+View the [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.deleteChannels.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.deleteChannels.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/alerts.deleteChannels.js`
+
+
+-----
+
+
+
+
+### Alerts.enable Policies
+
+View the [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.enablePolicies.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.enablePolicies.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/alerts.enablePolicies.js`
+
+
+-----
+
+
+
+
 ### Alerts
 
 View the [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.js).
@@ -44,6 +101,57 @@ __Usage:__
 
 
 `node samples/alerts.js`
+
+
+-----
+
+
+
+
+### Alerts.list Policies
+
+View the [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.listPolicies.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.listPolicies.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/alerts.listPolicies.js`
+
+
+-----
+
+
+
+
+### Alerts.replace Channels
+
+View the [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.replaceChannels.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.replaceChannels.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/alerts.replaceChannels.js`
+
+
+-----
+
+
+
+
+### Alerts.restore Policies
+
+View the [source code](https://github.com/googleapis/nodejs-monitoring/blob/master/samples/alerts.restorePolicies.js).
+
+[![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/nodejs-monitoring&page=editor&open_in_editor=samples/alerts.restorePolicies.js,samples/README.md)
+
+__Usage:__
+
+
+`node samples/alerts.restorePolicies.js`
 
 
 -----

--- a/samples/alerts.backupPolicies.js
+++ b/samples/alerts.backupPolicies.js
@@ -1,0 +1,60 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+function main(projectId) {
+  // [START monitoring_alert_backup_policies]
+  const fs = require('fs');
+
+  // Imports the Google Cloud client library
+  const monitoring = require('@google-cloud/monitoring');
+
+  // Creates a client
+  const client = new monitoring.AlertPolicyServiceClient();
+
+  async function backupPolicies() {
+    /**
+     * TODO(developer): Uncomment the following lines before running the sample.
+     */
+    // const projectId = 'YOUR_PROJECT_ID';
+
+    const listAlertPoliciesRequest = {
+      name: client.projectPath(projectId),
+    };
+
+    let [policies] = await client.listAlertPolicies(listAlertPoliciesRequest);
+
+    // filter out any policies created by tests for this sample
+    policies = policies.filter(policy => {
+      return !policy.displayName.startsWith('gcloud-tests-');
+    });
+
+    fs.writeFileSync(
+      './policies_backup.json',
+      JSON.stringify(policies, null, 2),
+      'utf-8'
+    );
+
+    console.log('Saved policies to ./policies_backup.json');
+    // [END monitoring_alert_backup_policies]
+  }
+  backupPolicies();
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/samples/alerts.deleteChannels.js
+++ b/samples/alerts.deleteChannels.js
@@ -1,0 +1,60 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+function main(projectId, filter) {
+  // [START monitoring_alert_delete_channel]
+  // [START monitoring_alert_list_channels]
+
+  // Imports the Google Cloud client library
+  const monitoring = require('@google-cloud/monitoring');
+
+  // Creates a client
+  const client = new monitoring.NotificationChannelServiceClient();
+
+  async function deleteChannels() {
+    /**
+     * TODO(developer): Uncomment the following lines before running the sample.
+     */
+    // const projectId = 'YOUR_PROJECT_ID';
+    // const filter = 'A filter for selecting policies, e.g. description:"cloud"';
+
+    const request = {
+      name: client.projectPath(projectId),
+      filter,
+    };
+    const channels = await client.listNotificationChannels(request);
+    console.log(channels);
+    for (const channel of channels[0]) {
+      console.log(`Deleting channel ${channel.displayName}`);
+      try {
+        await client.deleteNotificationChannel({
+          name: channel.name,
+        });
+      } catch (err) {
+        // ignore error
+      }
+    }
+  }
+  deleteChannels();
+  // [END monitoring_alert_delete_channel]
+  // [END monitoring_alert_list_channels]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/samples/alerts.enablePolicies.js
+++ b/samples/alerts.enablePolicies.js
@@ -1,0 +1,69 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+function main(projectId, enabled, filter) {
+  // [START monitoring_alert_enable_policies]
+  // Imports the Google Cloud client library
+  const monitoring = require('@google-cloud/monitoring');
+
+  // Creates a client
+  const client = new monitoring.AlertPolicyServiceClient();
+
+  async function enablePolicies() {
+    /**
+     * TODO(developer): Uncomment the following lines before running the sample.
+     */
+    // const projectId = 'YOUR_PROJECT_ID';
+    // const enabled = true;
+    // const filter = 'A filter for selecting policies, e.g. description:"cloud"';
+
+    const listAlertPoliciesRequest = {
+      name: client.projectPath(projectId),
+      // See https://cloud.google.com/monitoring/alerting/docs/sorting-and-filtering
+      filter: filter,
+    };
+
+    const [policies] = await client.listAlertPolicies(listAlertPoliciesRequest);
+    const responses = [];
+    for (const policy of policies) {
+      responses.push(
+        await client.updateAlertPolicy({
+          updateMask: {
+            paths: ['enabled'],
+          },
+          alertPolicy: {
+            name: policy.name,
+            enabled: {
+              value: enabled,
+            },
+          },
+        })
+      );
+    }
+    responses.forEach(response => {
+      const alertPolicy = response[0];
+      console.log(`${enabled ? 'Enabled' : 'Disabled'} ${alertPolicy.name}.`);
+    });
+  }
+  enablePolicies();
+  // [END monitoring_alert_enable_policies]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/samples/alerts.enablePolicies.js
+++ b/samples/alerts.enablePolicies.js
@@ -15,6 +15,8 @@
 'use strict';
 
 function main(projectId, enabled, filter) {
+  enabled = enabled === 'true';
+
   // [START monitoring_alert_enable_policies]
   // Imports the Google Cloud client library
   const monitoring = require('@google-cloud/monitoring');

--- a/samples/alerts.listPolicies.js
+++ b/samples/alerts.listPolicies.js
@@ -1,0 +1,51 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+function main(projectId) {
+  // [START monitoring_alert_list_policies]
+  // Imports the Google Cloud client library
+  const monitoring = require('@google-cloud/monitoring');
+
+  // Creates a client
+  const client = new monitoring.AlertPolicyServiceClient();
+
+  async function listPolicies() {
+    /**
+     * TODO(developer): Uncomment the following lines before running the sample.
+     */
+    // const projectId = 'YOUR_PROJECT_ID';
+
+    const listAlertPoliciesRequest = {
+      name: client.projectPath(projectId),
+    };
+    const [policies] = await client.listAlertPolicies(listAlertPoliciesRequest);
+    console.log('Policies:');
+    policies.forEach(policy => {
+      console.log(`  Display name: ${policy.displayName}`);
+      if (policy.documentation && policy.documentation.content) {
+        console.log(`     Documentation: ${policy.documentation.content}`);
+      }
+    });
+  }
+  listPolicies();
+  // [END monitoring_alert_list_policies]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/samples/alerts.replaceChannels.js
+++ b/samples/alerts.replaceChannels.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-function main(projectId, alertPolicyId, channelIds) {
+function main(projectId, alertPolicyId, ...channelIds) {
   // [START monitoring_alert_replace_channels]
   // [START monitoring_alert_enable_channel]
   // [START monitoring_alert_update_channel]

--- a/samples/alerts.replaceChannels.js
+++ b/samples/alerts.replaceChannels.js
@@ -1,0 +1,103 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+function main(projectId, alertPolicyId, channelIds) {
+  // [START monitoring_alert_replace_channels]
+  // [START monitoring_alert_enable_channel]
+  // [START monitoring_alert_update_channel]
+  // [START monitoring_alert_create_channel]
+
+  // Imports the Google Cloud client library
+  const monitoring = require('@google-cloud/monitoring');
+
+  // Creates clients
+  const alertClient = new monitoring.AlertPolicyServiceClient();
+  const notificationClient = new monitoring.NotificationChannelServiceClient();
+
+  async function replaceChannels() {
+    /**
+     * TODO(developer): Uncomment the following lines before running the sample.
+     */
+    // const projectId = 'YOUR_PROJECT_ID';
+    // const alertPolicyId = '123456789012314';
+    // const channelIds = [
+    //   'channel-1',
+    //   'channel-2',
+    //   'channel-3',
+    // ];
+
+    const notificationChannels = channelIds.map(id =>
+      notificationClient.projectNotificationChannelPath(projectId, id)
+    );
+
+    for (const channel of notificationChannels) {
+      const updateChannelRequest = {
+        updateMask: {
+          paths: ['enabled'],
+        },
+        notificationChannel: {
+          name: channel,
+          enabled: {
+            value: true,
+          },
+        },
+      };
+      try {
+        await notificationClient.updateNotificationChannel(
+          updateChannelRequest
+        );
+      } catch (err) {
+        const createChannelRequest = {
+          notificationChannel: {
+            name: channel,
+            notificationChannel: {
+              type: 'email',
+            },
+          },
+        };
+        const newChannel = await notificationClient.createNotificationChannel(
+          createChannelRequest
+        );
+        notificationChannels.push(newChannel);
+      }
+    }
+
+    const updateAlertPolicyRequest = {
+      updateMask: {
+        paths: ['notification_channels'],
+      },
+      alertPolicy: {
+        name: alertClient.projectAlertPolicyPath(projectId, alertPolicyId),
+        notificationChannels: notificationChannels,
+      },
+    };
+    const [alertPolicy] = await alertClient.updateAlertPolicy(
+      updateAlertPolicyRequest
+    );
+    console.log(`Updated ${alertPolicy.name}.`);
+  }
+  replaceChannels();
+  // [END monitoring_alert_replace_channels]
+  // [END monitoring_alert_enable_channel]
+  // [END monitoring_alert_update_channel]
+  // [END monitoring_alert_create_channel]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/samples/alerts.restorePolicies.js
+++ b/samples/alerts.restorePolicies.js
@@ -1,0 +1,88 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+function main(projectId) {
+  // [START monitoring_alert_restore_policies]
+  // [START monitoring_alert_create_policy]
+  const fs = require('fs');
+
+  // Imports the Google Cloud client library
+  const monitoring = require('@google-cloud/monitoring');
+
+  // Creates a client
+  const client = new monitoring.AlertPolicyServiceClient();
+
+  async function restorePolicies() {
+    // Note: The policies are restored one at a time due to limitations in
+    // the API. Otherwise, you may receive a 'service unavailable'  error
+    // while trying to create multiple alerts simultaneously.
+
+    /**
+     * TODO(developer): Uncomment the following lines before running the sample.
+     */
+    // const projectId = 'YOUR_PROJECT_ID';
+
+    console.log('Loading policies from ./policies_backup.json');
+    const fileContent = fs.readFileSync('./policies_backup.json', 'utf-8');
+    const policies = JSON.parse(fileContent);
+
+    for (const index in policies) {
+      // Restore each policy one at a time
+      let policy = policies[index];
+      if (await doesAlertPolicyExist(policy.name)) {
+        policy = await client.updateAlertPolicy({
+          alertPolicy: policy,
+        });
+      } else {
+        // Clear away output-only fields
+        delete policy.name;
+        delete policy.creationRecord;
+        delete policy.mutationRecord;
+        policy.conditions.forEach(condition => delete condition.name);
+
+        policy = await client.createAlertPolicy({
+          name: client.projectPath(projectId),
+          alertPolicy: policy,
+        });
+      }
+
+      console.log(`Restored ${policy[0].name}.`);
+    }
+    async function doesAlertPolicyExist(name) {
+      try {
+        const [policy] = await client.getAlertPolicy({
+          name,
+        });
+        return policy ? true : false;
+      } catch (err) {
+        if (err && err.code === 5) {
+          // Error code 5 comes from the google.rpc.code.NOT_FOUND protobuf
+          return false;
+        }
+        throw err;
+      }
+    }
+  }
+  restorePolicies();
+  // [END monitoring_alert_create_policy]
+  // [END monitoring_alert_restore_policies]
+}
+
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -14,60 +14,64 @@
 
 'use strict';
 
-// [START monitoring_quickstart]
-// Imports the Google Cloud client library
-const monitoring = require('@google-cloud/monitoring');
+async function main(projectId) {
+  // [START monitoring_quickstart]
+  // Imports the Google Cloud client library
+  const monitoring = require('@google-cloud/monitoring');
 
-async function quickstart() {
-  // Your Google Cloud Platform project ID
-  const projectId =
-    process.env.GCLOUD_PROJECT ||
-    process.env.GOOGLE_CLOUD_PROJECT ||
-    'YOUR_PROJECT_ID';
+  async function quickstart() {
+    // Creates a client
+    const client = new monitoring.MetricServiceClient();
 
-  // Creates a client
-  const client = new monitoring.MetricServiceClient();
+    // TODO(developer): Uncomment and set the following variables
+    // const projectId = "PROJECT_ID"
 
-  // Prepares an individual data point
-  const dataPoint = {
-    interval: {
-      endTime: {
-        seconds: Date.now() / 1000,
-      },
-    },
-    value: {
-      // The amount of sales
-      doubleValue: 123.45,
-    },
-  };
-
-  // Prepares the time series request
-  const request = {
-    name: client.projectPath(projectId),
-    timeSeries: [
-      {
-        // Ties the data point to a custom metric
-        metric: {
-          type: 'custom.googleapis.com/stores/daily_sales',
-          labels: {
-            store_id: 'Pittsburgh',
-          },
+    // Prepares an individual data point
+    const dataPoint = {
+      interval: {
+        endTime: {
+          seconds: Date.now() / 1000,
         },
-        resource: {
-          type: 'global',
-          labels: {
-            project_id: projectId,
-          },
-        },
-        points: [dataPoint],
       },
-    ],
-  };
+      value: {
+        // The amount of sales
+        doubleValue: 123.45,
+      },
+    };
 
-  // Writes time series data
-  const [result] = await client.createTimeSeries(request);
-  console.log('Done writing time series data.', result);
+    // Prepares the time series request
+    const request = {
+      name: client.projectPath(projectId),
+      timeSeries: [
+        {
+          // Ties the data point to a custom metric
+          metric: {
+            type: 'custom.googleapis.com/stores/daily_sales',
+            labels: {
+              store_id: 'Pittsburgh',
+            },
+          },
+          resource: {
+            type: 'global',
+            labels: {
+              project_id: projectId,
+            },
+          },
+          points: [dataPoint],
+        },
+      ],
+    };
+
+    // Writes time series data
+    const [result] = await client.createTimeSeries(request);
+    console.log('Done writing time series data.', result);
+  }
+  quickstart();
+  // [END monitoring_quickstart]
 }
-// [END monitoring_quickstart]
 
-quickstart().catch(console.error);
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/samples/test/alerts.test.js
+++ b/samples/test/alerts.test.js
@@ -26,10 +26,7 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 
 const client = new monitoring.AlertPolicyServiceClient();
 const channelClient = new monitoring.NotificationChannelServiceClient();
-const projectId =
-  process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT;
-const cmd = 'node alerts';
-
+let projectId;
 let policyOneName, policyTwoName, channelName;
 const testPrefix = `gcloud-test-${uuid.v4().split('-')[0]}`;
 
@@ -48,6 +45,7 @@ const delay = async test => {
 
 describe('alerts', () => {
   before(async () => {
+    projectId = await client.getProjectId();
     await reapPolicies();
     let results = await client.createAlertPolicy({
       name: client.projectPath(projectId),
@@ -179,7 +177,9 @@ describe('alerts', () => {
   it('should replace notification channels', async function () {
     this.retries(8);
     await delay(this.test);
-    const stdout = execSync(`${cmd} replace ${policyOneName} ${channelName}`);
+    const stdout = execSync(
+      `node alerts.replaceChannels.js ${policyOneName} ${channelName}`
+    );
     assert.include(stdout, 'Updated projects');
     assert.include(stdout, policyOneName);
   });
@@ -188,7 +188,7 @@ describe('alerts', () => {
     this.retries(8);
     await delay(this.test);
     const stdout = execSync(
-      `${cmd} disable ${projectId} 'display_name.size < 28'`
+      `node alerts.enablePolicies.js ${projectId} false 'display_name.size < 28'`
     );
     assert.include(stdout, 'Disabled projects');
     assert.notInclude(stdout, policyOneName);
@@ -199,7 +199,7 @@ describe('alerts', () => {
     this.retries(8);
     await delay(this.test);
     const stdout = execSync(
-      `${cmd} enable ${projectId} 'display_name.size < 28'`
+      `node alerts.enablePolicies.js ${projectId} true 'display_name.size < 28'`
     );
     assert.include(stdout, 'Enabled projects');
     assert.notInclude(stdout, policyOneName);
@@ -207,7 +207,7 @@ describe('alerts', () => {
   });
 
   it('should list policies', () => {
-    const stdout = execSync(`${cmd} list ${projectId}`);
+    const stdout = execSync(`node alerts.listPolicies.js ${projectId}`);
     assert.include(stdout, 'Policies:');
     assert.include(stdout, 'first-policy');
     assert.include(stdout, 'Test');
@@ -217,7 +217,7 @@ describe('alerts', () => {
   it('should backup all policies', async function () {
     this.retries(8);
     await delay(this.test);
-    const output = execSync(`${cmd} backup ${projectId}`);
+    const output = execSync(`node backupPolicies.js ${projectId}`);
     assert.include(output, 'Saved policies to ./policies_backup.json');
     assert.ok(fs.existsSync(path.join(__dirname, '../policies_backup.json')));
     await client.deleteAlertPolicy({name: policyOneName});
@@ -226,7 +226,7 @@ describe('alerts', () => {
   it('should restore policies', async function () {
     this.retries(8);
     await delay(this.test);
-    const output = execSync(`${cmd} restore ${projectId}`);
+    const output = execSync(`node restorePolicies.js ${projectId}`);
     assert.include(output, 'Loading policies from ./policies_backup.json');
     const matches = output.match(
       /projects\/[A-Za-z0-9-]+\/alertPolicies\/([\d]+)/gi

--- a/samples/test/alerts.test.js
+++ b/samples/test/alerts.test.js
@@ -177,15 +177,19 @@ describe('alerts', () => {
   it('should replace notification channels', async function () {
     this.retries(8);
     await delay(this.test);
+    const parts = policyOneName.split('/');
+    const projectId = parts[1];
+    const alertPolicyId = parts[3];
+    const channelId = channelName.split('/')[3];
     const stdout = execSync(
-      `node alerts.replaceChannels.js ${policyOneName} ${channelName}`
+      `node alerts.replaceChannels.js ${projectId} ${alertPolicyId} ${channelId}`
     );
     assert.include(stdout, 'Updated projects');
     assert.include(stdout, policyOneName);
   });
 
   it('should disable policies', async function () {
-    this.retries(8);
+    //this.retries(8);
     await delay(this.test);
     const stdout = execSync(
       `node alerts.enablePolicies.js ${projectId} false 'display_name.size < 28'`
@@ -217,7 +221,7 @@ describe('alerts', () => {
   it('should backup all policies', async function () {
     this.retries(8);
     await delay(this.test);
-    const output = execSync(`node backupPolicies.js ${projectId}`);
+    const output = execSync(`node alerts.backupPolicies.js ${projectId}`);
     assert.include(output, 'Saved policies to ./policies_backup.json');
     assert.ok(fs.existsSync(path.join(__dirname, '../policies_backup.json')));
     await client.deleteAlertPolicy({name: policyOneName});
@@ -226,7 +230,7 @@ describe('alerts', () => {
   it('should restore policies', async function () {
     this.retries(8);
     await delay(this.test);
-    const output = execSync(`node restorePolicies.js ${projectId}`);
+    const output = execSync(`node alerts.restorePolicies.js ${projectId}`);
     assert.include(output, 'Loading policies from ./policies_backup.json');
     const matches = output.match(
       /projects\/[A-Za-z0-9-]+\/alertPolicies\/([\d]+)/gi

--- a/samples/test/quickstart.test.js
+++ b/samples/test/quickstart.test.js
@@ -15,8 +15,11 @@
 'use strict';
 
 const {assert} = require('chai');
-const {describe, it} = require('mocha');
+const {describe, it, before} = require('mocha');
 const cp = require('child_process');
+const monitoring = require('@google-cloud/monitoring');
+
+const client = new monitoring.AlertPolicyServiceClient();
 
 const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 // Tests in this suite can trigger the upstream error,
@@ -33,10 +36,14 @@ const delay = async test => {
   });
 };
 describe('quickstart', () => {
+  let projectId;
+  before(async () => {
+    projectId = await client.getProjectId();
+  });
   it('should run the quickstart', async function () {
     this.retries(8);
     await delay(this.test); // delay the start of the test, if this is a retry.
-    const result = execSync('node quickstart');
+    const result = execSync(`node quickstart ${projectId}`);
     assert.match(result, /Done writing time series data/);
   });
 });

--- a/samples/test/quickstart.test.js
+++ b/samples/test/quickstart.test.js
@@ -43,7 +43,7 @@ describe('quickstart', () => {
   it('should run the quickstart', async function () {
     this.retries(8);
     await delay(this.test); // delay the start of the test, if this is a retry.
-    const result = execSync(`node quickstart ${projectId}`);
+    const result = execSync(`node quickstart.js ${projectId}`);
     assert.match(result, /Done writing time series data/);
   });
 });


### PR DESCRIPTION
I noticed some inconsistencies with the snippets on cloudsite.  This starts us down the path of modernizing our monitoring snippets by splitting alerts, and by fixing issues with the quickstart.  This will be followed by updates to devrel/snippets to use the new split snippets, and a followup PR that deletes the original `alert.js`.  