### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -3,12 +3,14 @@
   "product_documentation": "https://cloud.google.com/monitoring/docs",
   "name": "monitoring",
   "requires_billing": true,
-  "release_level": "ga",
+  "release_level": "stable",
   "language": "nodejs",
   "api_id": "monitoring.googleapis.com",
   "distribution_name": "@google-cloud/monitoring",
   "repo": "googleapis/nodejs-monitoring",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559785",
   "name_pretty": "Stackdriver Monitoring",
-  "default_version": "v3"
+  "default_version": "v3",
+  "api_shortname": "monitoring",
+  "library_type": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -12,5 +12,5 @@
   "name_pretty": "Stackdriver Monitoring",
   "default_version": "v3",
   "api_shortname": "monitoring",
-  "library_type": ""
+  "library_type": "GAPIC_AUTO"
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Stackdriver Monitoring: Node.js Client](https://github.com/googleapis/nodejs-monitoring)
 
-[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+
 [![npm version](https://img.shields.io/npm/v/@google-cloud/monitoring.svg)](https://www.npmjs.org/package/@google-cloud/monitoring)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-monitoring/main.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-monitoring)
 
@@ -172,12 +172,6 @@ _Legacy Node.js versions are supported as a best effort:_
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-
-This library is considered to be **General Availability (GA)**. This means it
-is stable; the code surface will not change in backwards-incompatible ways
-unless absolutely necessary (e.g. because of critical security issues) or with
-an extensive deprecation period. Issues and requests against **GA** libraries
-are addressed with the highest priority.
 
 
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 
 
+This library is considered to be **stable**. The code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **stable** libraries
+are addressed with the highest priority.
+
 
 
 


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 